### PR TITLE
Add --debug flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::sync::OnceLock;
 
 mod utility;
 use utility::{
@@ -15,6 +16,9 @@ use utility::{
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    #[arg(short, long, help = "Show debug information", global = true)]
+    debug: bool,
 }
 
 #[derive(Subcommand)]
@@ -34,18 +38,35 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+    if cli.debug {
+        let _ = DEBUG_FLAG.set(true);
+    }
 
     if let Err(err) = run_cli(cli) {
-        eprintln!("{}", err);
+        eprintln!("Error: {}", err);
         std::process::exit(1);
     }
 }
 
+static DEBUG_FLAG: OnceLock<bool> = OnceLock::new();
+
+pub fn is_debug() -> bool {
+    *DEBUG_FLAG.get().unwrap_or(&false)
+}
+
+pub fn debug_println(msg: &str) {
+    if is_debug() {
+        println!("[DEBUG] {}", msg);
+    }
+}
+
 fn run_cli(cli: Cli) -> Result<(), CliError> {
+    debug_println("Starting ADB wireless tool");
     adb_ensure_running()?;
 
     match cli.command {
         Commands::Reverse { ports } => {
+            debug_println("Listing connected devices");
             let devices = adb_list_devices()?;
 
             if devices.is_empty() {
@@ -66,6 +87,10 @@ fn run_cli(cli: Cli) -> Result<(), CliError> {
             // Handle reverse port mapping
             for port in ports {
                 let mapping = PortMapping::new(&port)?;
+                debug_println(&format!(
+                    "Reversing port {} to {} on device {}",
+                    mapping.device_port, mapping.host_port, selected_device
+                ));
                 adb_reverse_port(&selected_device, &mapping)?;
                 println!(
                     "Reversed port {}:{}",
@@ -74,17 +99,20 @@ fn run_cli(cli: Cli) -> Result<(), CliError> {
             }
         }
         Commands::Pair => {
+            debug_println("Starting pairing service");
             let service = PairService::new()?;
             service.start_discovery()?;
 
             qr2term::print_qr(service.qrtext())?;
             println!("QR code generated. Scan it with your device to pair.");
 
+            debug_println("Waiting for device to pair...");
             let device = service.wait_for_pairing()?;
-            println!(
-                "Device found at {}:{}",
-                device.address, device.debugging_port
-            );
+            println!("Device found, pairing...");
+            debug_println(&format!(
+                "Device found: address={}, pairing_port={}, debugging_port={}",
+                device.address, device.pairing_port, device.debugging_port
+            ));
             adb_connect_device(&device, &service.password)?;
 
             println!("Device connected");

--- a/src/utility/adb.rs
+++ b/src/utility/adb.rs
@@ -1,6 +1,7 @@
 use super::{error::CliError, pair::DeviceInfo, port::PortMapping};
 
 pub fn adb_ensure_running() -> Result<(), CliError> {
+    crate::debug_println("Checking if ADB is installed");
     // Check if ADB exists
     match std::process::Command::new("adb").arg("version").output() {
         Ok(output) => {
@@ -11,17 +12,17 @@ pub fn adb_ensure_running() -> Result<(), CliError> {
         Err(_) => return Err(CliError::AdbNotFound),
     }
 
+    crate::debug_println("Starting ADB server");
     // Start ADB server
     let mut cmd = std::process::Command::new("adb");
     cmd.arg("start-server");
 
-    let mut child = cmd.spawn().map_err(|err| CliError::AdbServerError(err))?;
+    let mut child = cmd.spawn().map_err(CliError::AdbServerError)?;
 
     match child.wait() {
         Ok(status) => {
             if !status.success() {
-                return Err(CliError::AdbServerError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(CliError::AdbServerError(std::io::Error::other(
                     "Failed to start ADB server.".to_string(),
                 )));
             }
@@ -33,19 +34,17 @@ pub fn adb_ensure_running() -> Result<(), CliError> {
 }
 
 pub fn adb_list_devices() -> Result<Vec<String>, CliError> {
+    crate::debug_println("Running 'adb devices'");
     let output = std::process::Command::new("adb")
         .arg("devices")
         .output()
-        .map_err(|err| CliError::AdbServerError(err))?;
+        .map_err(CliError::AdbServerError)?;
 
     if !output.status.success() {
-        return Err(CliError::AdbServerError(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "Failed to list devices. {}",
-                String::from_utf8_lossy(&output.stderr)
-            ),
-        )));
+        return Err(CliError::AdbServerError(std::io::Error::other(format!(
+            "Failed to list devices. {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -66,6 +65,10 @@ pub fn adb_list_devices() -> Result<Vec<String>, CliError> {
 }
 
 pub fn adb_reverse_port(device_name: &str, mapping: &PortMapping) -> Result<(), CliError> {
+    crate::debug_println(&format!(
+        "Running 'adb -s {} reverse tcp:{} tcp:{}'",
+        device_name, mapping.device_port, mapping.host_port
+    ));
     match std::process::Command::new("adb")
         .arg("-s")
         .arg(device_name)
@@ -76,15 +79,12 @@ pub fn adb_reverse_port(device_name: &str, mapping: &PortMapping) -> Result<(), 
     {
         Ok(output) => {
             if !output.status.success() {
-                return Err(CliError::AdbServerError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Failed to reverse port {}:{}. {}",
-                        mapping.device_port,
-                        mapping.host_port,
-                        String::from_utf8_lossy(&output.stderr)
-                    ),
-                )));
+                return Err(CliError::AdbServerError(std::io::Error::other(format!(
+                    "Failed to reverse port {}:{}. {}",
+                    mapping.device_port,
+                    mapping.host_port,
+                    String::from_utf8_lossy(&output.stderr)
+                ))));
             }
         }
         Err(err) => return Err(CliError::AdbServerError(err)),
@@ -94,6 +94,10 @@ pub fn adb_reverse_port(device_name: &str, mapping: &PortMapping) -> Result<(), 
 }
 
 pub fn adb_connect_device(device: &DeviceInfo, password: &str) -> Result<(), CliError> {
+    crate::debug_println(&format!(
+        "Running 'adb pair {}:{} {}'",
+        device.address, device.pairing_port, password
+    ));
     match std::process::Command::new("adb")
         .arg("pair")
         .arg(format!("{}:{}", device.address, device.pairing_port))
@@ -102,36 +106,34 @@ pub fn adb_connect_device(device: &DeviceInfo, password: &str) -> Result<(), Cli
     {
         Ok(output) => {
             if !output.status.success() {
-                return Err(CliError::AdbServerError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Failed to pair with device at {}:{}. {}",
-                        device.address,
-                        device.pairing_port,
-                        String::from_utf8_lossy(&output.stderr)
-                    ),
-                )));
+                return Err(CliError::AdbServerError(std::io::Error::other(format!(
+                    "Failed to pair with device at {}:{}. {}",
+                    device.address,
+                    device.pairing_port,
+                    String::from_utf8_lossy(&output.stderr)
+                ))));
             }
         }
         Err(err) => return Err(CliError::AdbServerError(err)),
     }
 
+    crate::debug_println(&format!(
+        "Running 'adb connect {}:{}'",
+        device.address, device.debugging_port
+    ));
     let mut cmd = std::process::Command::new("adb");
     cmd.arg("connect")
         .arg(format!("{}:{}", device.address, device.debugging_port));
 
-    let mut child = cmd.spawn().map_err(|err| CliError::AdbServerError(err))?;
+    let mut child = cmd.spawn().map_err(CliError::AdbServerError)?;
 
     match child.wait() {
         Ok(status) => {
             if !status.success() {
-                return Err(CliError::AdbServerError(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Failed to connect to device at {}:{}",
-                        device.address, device.debugging_port,
-                    ),
-                )));
+                return Err(CliError::AdbServerError(std::io::Error::other(format!(
+                    "Failed to connect to device at {}:{}",
+                    device.address, device.debugging_port,
+                ))));
             }
         }
         Err(err) => return Err(CliError::AdbServerError(err)),

--- a/src/utility/pair.rs
+++ b/src/utility/pair.rs
@@ -33,6 +33,11 @@ impl PairService {
         let service_name = format!("adb-wireless-{}", random_number_string(6));
         let password = random_number_string(8);
 
+        crate::debug_println(&format!(
+            "Created PairService: service_name={}, password={}",
+            service_name, password
+        ));
+
         Ok(Self {
             service_name,
             password,
@@ -45,6 +50,10 @@ impl PairService {
     }
 
     pub fn start_discovery(&self) -> Result<(), CliError> {
+        crate::debug_println(&format!(
+            "Registering mDNS service: {} type: {}",
+            self.service_name, SERVICE_TYPE_PAIRING
+        ));
         let service_info = ServiceInfo::new(
             SERVICE_TYPE_PAIRING,
             &self.service_name,
@@ -60,6 +69,10 @@ impl PairService {
     }
 
     pub fn wait_for_pairing(&self) -> Result<DeviceInfo, CliError> {
+        crate::debug_println(&format!(
+            "Browsing for mDNS service: {}",
+            SERVICE_TYPE_PAIRING
+        ));
         // first browse for pairing service
         let receiver = self.mdns.browse(SERVICE_TYPE_PAIRING)?;
 
@@ -71,11 +84,7 @@ impl PairService {
                         let port = info.get_port();
 
                         let _ = self.mdns.stop_browse(SERVICE_TYPE_PAIRING);
-                        if let Some(addr) = client_addresses
-                            .iter()
-                            .filter(|addr| addr.is_private())
-                            .next()
-                        {
+                        if let Some(addr) = client_addresses.iter().find(|addr| addr.is_private()) {
                             break (**addr, port);
                         } else {
                             return Err(CliError::MdnsError(mdns_sd::Error::Msg(
@@ -91,6 +100,11 @@ impl PairService {
                 }
             }
         };
+
+        crate::debug_println(&format!(
+            "Pairing service resolved at {}:{}. Now browsing for connect service: {}",
+            address, pairing_port, SERVICE_TYPE_CONNECT
+        ));
 
         // then browse for connect service
         let receiver = self.mdns.browse(SERVICE_TYPE_CONNECT)?;
@@ -112,6 +126,7 @@ impl PairService {
 
                     if info.get_addresses_v4().iter().any(|&&addr| addr == address) {
                         let _ = self.mdns.stop_browse(SERVICE_TYPE_CONNECT);
+                        crate::debug_println(&format!("Connect service resolved at port {}", port));
                         break port;
                     } else {
                         std::thread::sleep(std::time::Duration::from_millis(100))


### PR DESCRIPTION
I ran into some situations where the CLI tool was stuck (#2 #3), and I wanted to see why that happened. I added a `--debug` flag:

```
adb-wireless pair --debug                                                                                                         11:09:49
[DEBUG] Starting ADB wireless tool
[DEBUG] Checking if ADB is installed
[DEBUG] Starting ADB server
[DEBUG] Starting pairing service
[DEBUG] Created PairService: service_name=adb-wireless-306752, password=xxxxxxxx
[DEBUG] Registering mDNS service: adb-wireless-306752 type: _adb-tls-pairing._tcp.local.
QR code generated. Scan it with your device to pair.
[DEBUG] Waiting for device to pair...
[DEBUG] Browsing for mDNS service: _adb-tls-pairing._tcp.local.
[DEBUG] Pairing service resolved at 192.168.0.144:39889. Now browsing for connect service: _adb-tls-connect._tcp.local.
[DEBUG] Connect service resolved at port 45233
[DEBUG] Device found: address=192.168.0.144, pairing_port=39889, debugging_port=45233
[DEBUG] Running 'adb pair 192.168.0.144:39889 xxxxxxx'
[DEBUG] Running 'adb connect 192.168.0.144:45233'
connected to 192.168.0.144:45233
Device connected
```